### PR TITLE
Deploy table without -a option

### DIFF
--- a/deploy/database.py
+++ b/deploy/database.py
@@ -67,7 +67,7 @@ def dump(config, rawtables, savedir):
                 cmd = [] + dump  # clone dump
                 cmd += ['-n'] if config['use_schema'] in ('true', 'yes', '1') \
                     else ['-t']
-                cmd += [table, database]
+                cmd += ["%s" % table, database]
                 output = file(os.path.join(savedir, database + '.' + table + '.dump'), 'w+b')
                 errors = file(os.path.join(savedir, database + '.' + table + '.dump.log'), 'w')
 
@@ -129,9 +129,9 @@ def truncate_table(database, table, psqlcmd=['psql'], is_schema=False):
         errors = tempfile.TemporaryFile()
         cmd = psqlcmd + [
             '-c',
-            "TRUNCATE TABLE %(table)s" % {'table': table}
+            'TRUNCATE TABLE "%(table)s"' % {'table': table}
             if not is_schema else
-            "DROP SCHEMA IF EXISTS %(schema)s CASCADE" % {'schema': table},
+            'DROP SCHEMA IF EXISTS "%(schema)s" CASCADE' % {'schema': table},
             database
         ]
         logger.debug("deleting '%(database)s.%(table)s' with '%(cmd)s'" % {


### PR DESCRIPTION
When deploying database table by table, please do not use the -a option
because otherwise new indexes are not deployed

fix #11
fix #10
