### PR TITLE
make deploy compatible with systemd

### DIFF
--- a/config/hooks-database/post-restore-database-swap
+++ b/config/hooks-database/post-restore-database-swap
@@ -7,7 +7,9 @@
 
 DATABASES=$@
 
-if [ -x /etc/init.d/apache2 ]; then
+if [ -x /bin/systemctl ]; then
+    sudo /bin/systemctl start apache2
+elif [ -x /etc/init.d/apache2 ]
     sudo /etc/init.d/apache2 start
 fi
 

--- a/config/hooks-database/pre-restore-database-swap
+++ b/config/hooks-database/pre-restore-database-swap
@@ -7,7 +7,9 @@
 
 DATABASES=$@
 
-if [ -x /etc/init.d/apache2 ]; then
+if [ -x /bin/systemctl ]; then
+    sudo /bin/systemctl stop apache2
+elif [ -x /etc/init.d/apache2 ]
     sudo /etc/init.d/apache2 stop
 fi
 

--- a/config/hooks/post-restore
+++ b/config/hooks/post-restore
@@ -7,6 +7,8 @@
 
 rm /tmp/np
 
-if [ -x /etc/init.d/apache2 ]; then
+if [ -x /bin/systemctl ]; then
+    sudo /bin/systemctl start apache2
+elif [ -x /etc/init.d/apache2 ]
     sudo /etc/init.d/apache2 start
 fi

--- a/config/hooks/pre-restore
+++ b/config/hooks/pre-restore
@@ -5,7 +5,9 @@
 #            section in config file)
 #
 
-if [ -x /etc/init.d/apache2 ]; then
+if [ -x /bin/systemctl ]; then
+    sudo /bin/systemctl stop apache2
+elif [ -x /etc/init.d/apache2 ]
     sudo /etc/init.d/apache2 stop
 fi
 

--- a/config/hooks/pre-restore-database
+++ b/config/hooks/pre-restore-database
@@ -9,6 +9,8 @@ DATABASES=$@
 
 # apache must be stopped to prevent database connection during
 # databases / tables restore.
-if [ -x /etc/init.d/apache2 ]; then
+if [ -x /bin/systemctl ]; then
+    sudo /bin/systemctl stop apache2
+elif [ -x /etc/init.d/apache2 ]
     sudo /etc/init.d/apache2 stop
 fi


### PR DESCRIPTION
due to the way puppet check if apache is running, now the only compatible way to stop/start apache is by using systemctl, otherwise it causes some problem with puppet miss-detecting apache is not running and stop apache as a result