### PR TITLE
Only stop/start apache when deploying a database

### DIFF
--- a/config/hooks/post-restore
+++ b/config/hooks/post-restore
@@ -4,11 +4,3 @@
 #   $TARGET: name of the symbolic remote host key (see remote_hosts
 #            section in config file)
 #
-
-rm /tmp/np
-
-if [ -x /bin/systemctl ]; then
-    sudo /bin/systemctl start apache2
-elif [ -x /etc/init.d/apache2 ]; then
-    sudo /etc/init.d/apache2 start
-fi

--- a/config/hooks/post-restore-database
+++ b/config/hooks/post-restore-database
@@ -15,3 +15,9 @@ DATABASES=$@
 # do
 #   psql -c "VACUUM ANALYZE;" $b
 # done
+
+if [ -x /bin/systemctl ]; then
+    sudo /bin/systemctl start apache2
+elif [ -x /etc/init.d/apache2 ]; then
+    sudo /etc/init.d/apache2 start
+fi

--- a/config/hooks/pre-restore
+++ b/config/hooks/pre-restore
@@ -4,11 +4,3 @@
 #   $TARGET: name of the symbolic remote host key (see remote_hosts
 #            section in config file)
 #
-
-if [ -x /bin/systemctl ]; then
-    sudo /bin/systemctl stop apache2
-elif [ -x /etc/init.d/apache2 ]; then
-    sudo /etc/init.d/apache2 stop
-fi
-
-echo "Deploy '$TARGET' at `date`" > /tmp/np


### PR DESCRIPTION
dont do it when deploying code because the GMF build process will try to do a graceful at the end of the build and will cause a logical problem if apache is also handled by deploy.